### PR TITLE
Update demo images to v2

### DIFF
--- a/macos/Makefile
+++ b/macos/Makefile
@@ -1,7 +1,7 @@
 REGISTRY = quay.io
 USER = nirsof
 IMAGE = vulkan-demo
-TAG = v1
+TAG = v2
 TOOL = podman
 
 image_url = $(REGISTRY)/$(USER)/$(IMAGE):$(TAG)

--- a/macos/demo-cpu.yaml
+++ b/macos/demo-cpu.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   containers:
   - name: vulkan-demo
-    image: quay.io/nirsof/vulkan-demo:v1
+    image: quay.io/nirsof/vulkan-demo:v2
     command: ["sh", "-c" , "trap 'exit 0' TERM; while true; do sleep 60 & wait; done"]

--- a/macos/demo-gpu.yaml
+++ b/macos/demo-gpu.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: vulkan-demo
-    image: quay.io/nirsof/vulkan-demo:v1
+    image: quay.io/nirsof/vulkan-demo:v2
     command: ["sh", "-c" , "trap 'exit 0' TERM; while true; do sleep 60 & wait; done"]
     resources:
       limits:

--- a/macos/uvkc-cpu.yaml
+++ b/macos/uvkc-cpu.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   containers:
   - name: uvkc
-    image: quay.io/nirsof/uvkc:v1
+    image: quay.io/nirsof/uvkc:v2
     command: ["sh", "-c" , "trap 'exit 0' TERM; while true; do sleep 60 & wait; done"]

--- a/macos/uvkc-gpu.yaml
+++ b/macos/uvkc-gpu.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: uvkc
-    image: quay.io/nirsof/uvkc:v1
+    image: quay.io/nirsof/uvkc:v2
     command: ["sh", "-c" , "trap 'exit 0' TERM; while true; do sleep 60 & wait; done"]
     resources:
       limits:


### PR DESCRIPTION
Built using latest version of slp/fedora-vgpu based on Fedora 42 and much smaller.

The images are much smaller now:
    
| image       | v1        | v2        |
|-------------|-----------|-----------|
| vulkan-demo | 450.9 MiB | 189.4 MiB |
| uvkc        | 462.6 MiB | 201.0 MiB |

Tested with https://github.com/kubernetes/minikube/pull/20826

Fixes #5 